### PR TITLE
get IWpfShell from serviceProvider

### DIFF
--- a/src/Dapplo.Microsoft.Extensions.Hosting.Wpf/HostBuilderWpfExtensions.cs
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.Wpf/HostBuilderWpfExtensions.cs
@@ -90,7 +90,8 @@ namespace Dapplo.Microsoft.Extensions.Hosting.Wpf
             hostBuilder.ConfigureWpf(configureAction);
             hostBuilder.ConfigureServices((hostBuilderContext, serviceCollection) =>
             {
-                serviceCollection.AddSingleton<IWpfShell, TShell>();
+                serviceCollection.AddSingleton<TShell>();
+                serviceCollection.AddSingleton<IWpfShell, TShell>(serviceProvider => serviceProvider.GetRequiredService<TShell>());
             });
             return hostBuilder;
         }


### PR DESCRIPTION
This patch registers TShell as singleton and lets IWpfShell resolve to the TShell registered earlier.

This avoids that we get different instances when we ask the service provider to get an instance of our TShell or when internally an IWpfShell is requested.

It is discussabel who is responsible for registering the TShell singleton in the serviceContainer. In this patch it is also done by ConfigureWpf

see: 
https://stackoverflow.com/questions/41810986/asp-net-core-register-implementation-with-multiple-interfaces-and-lifestyle-sin/41812930