### PR TITLE
Cancel the starting of WPF thread

### DIFF
--- a/src/Dapplo.Microsoft.Extensions.Hosting.Wpf/WpfHostedService.cs
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.Wpf/WpfHostedService.cs
@@ -35,6 +35,11 @@ namespace Dapplo.Microsoft.Extensions.Hosting.Wpf
         /// <inheritdoc />
         public Task StartAsync(CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.CompletedTask;
+            }
+            
             // Make the UI thread go
             _wpfThread.Start();
             return Task.CompletedTask;


### PR DESCRIPTION
This avoids the behavior in combination with the single instance extension that a window still pops up when another instance is already running.