### PR TITLE
Notify first instance that another instance has started

### DIFF
--- a/samples/Dapplo.Hosting.Sample.WpfDemo/Program.cs
+++ b/samples/Dapplo.Hosting.Sample.WpfDemo/Program.cs
@@ -34,6 +34,11 @@ namespace Dapplo.Hosting.Sample.WpfDemo
                         // This is called when an instance was already started, this is in the second instance
                         logger.LogWarning("Application {0} already running.", hostingEnvironment.ApplicationName);
                     };
+
+                    builder.WhenOtherInstanceStarts = (hostingEnvironment, logger) =>
+                    {
+                        logger.LogInformation("Another instance of application {0} tries to start", hostingEnvironment.ApplicationName);
+                    };
                 })
                 .ConfigurePlugins(pluginBuilder =>
                 {

--- a/src/Dapplo.Microsoft.Extensions.Hosting.AppServices/BaseResourceNamedPipe.cs
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.AppServices/BaseResourceNamedPipe.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Dapplo and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+#if NET472
+using System.Security.AccessControl;
+using System.Security.Principal;
+#endif
+
+namespace Dapplo.Microsoft.Extensions.Hosting.AppServices
+{
+    /// <summary>
+    ///     This is a base class for named pipe resources
+    /// </summary>
+    public abstract class BaseResourceNamedPipe
+    {
+        protected const string StartedMagicString = "__STARTED__";
+        protected readonly ILogger _logger;
+        protected readonly string _namedPipeId;
+        protected readonly string _resourceName;
+
+        /// <summary>
+        ///     Protected constructor
+        /// </summary>
+        /// <param name="logger">ILogger</param>
+        /// <param name="namedPipeId">string with a unique Named Pipe ID</param>
+        /// <param name="resourceName">optional name for the resource</param>
+        protected BaseResourceNamedPipe(ILogger logger, string namedPipeId, string resourceName = null)
+        {
+            _logger = logger;
+            _namedPipeId = namedPipeId;
+            _resourceName = resourceName ?? namedPipeId;
+        }
+    }
+}

--- a/src/Dapplo.Microsoft.Extensions.Hosting.AppServices/IMutexBuilder.cs
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.AppServices/IMutexBuilder.cs
@@ -26,5 +26,10 @@ namespace Dapplo.Microsoft.Extensions.Hosting.AppServices
         /// The action which is called when the mutex cannot be locked
         /// </summary>
         Action<IHostEnvironment, ILogger> WhenNotFirstInstance { get; set; }
+
+        /// <summary>
+        /// The action which is called when another instance attempted to start
+        /// </summary>
+        Action<IHostEnvironment, ILogger> WhenOtherInstanceStarts { get; set; }
     }
 }

--- a/src/Dapplo.Microsoft.Extensions.Hosting.AppServices/Internal/MutexBuilder.cs
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.AppServices/Internal/MutexBuilder.cs
@@ -20,5 +20,8 @@ namespace Dapplo.Microsoft.Extensions.Hosting.AppServices.Internal
 
         /// <inheritdoc />
         public Action<IHostEnvironment, ILogger> WhenNotFirstInstance { get; set; }
+
+        /// <inheritdoc />
+        public Action<IHostEnvironment, ILogger> WhenOtherInstanceStarts { get; set; }
     }
 }

--- a/src/Dapplo.Microsoft.Extensions.Hosting.AppServices/Internal/MutexLifetimeService.cs
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.AppServices/Internal/MutexLifetimeService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Dapplo and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
@@ -18,6 +19,7 @@ namespace Dapplo.Microsoft.Extensions.Hosting.AppServices.Internal
         private readonly IHostApplicationLifetime _hostApplicationLifetime;
         private readonly IMutexBuilder _mutexBuilder;
         private ResourceMutex _resourceMutex;
+        private ResourceNamedPipeServer _resourceNamedPipeServer;
 
         public MutexLifetimeService(ILogger<MutexLifetimeService> logger, IHostEnvironment hostEnvironment, IHostApplicationLifetime hostApplicationLifetime, IMutexBuilder mutexBuilder)
         {
@@ -27,7 +29,7 @@ namespace Dapplo.Microsoft.Extensions.Hosting.AppServices.Internal
             _mutexBuilder = mutexBuilder;
         }
 
-        public Task StartAsync(CancellationToken cancellationToken)
+        public async Task StartAsync(CancellationToken cancellationToken)
         {
             _resourceMutex = ResourceMutex.Create(null, _mutexBuilder.MutexId, _hostEnvironment.ApplicationName, _mutexBuilder.IsGlobal);
 
@@ -35,16 +37,41 @@ namespace Dapplo.Microsoft.Extensions.Hosting.AppServices.Internal
             if (!_resourceMutex.IsLocked)
             {
                 _mutexBuilder.WhenNotFirstInstance?.Invoke(_hostEnvironment, _logger);
-                _logger.LogDebug("Application {0} already running, stopping application.", _hostEnvironment.ApplicationName);
+                _logger.LogDebug("Application {0} already running, notifying other instance.", _hostEnvironment.ApplicationName);
+
+                try
+                {
+                    using var client = await ResourceNamedPipeClient.Create(null, _mutexBuilder.MutexId, _hostEnvironment.ApplicationName, _mutexBuilder.IsGlobal);
+                }
+                catch(Exception e)
+                {
+                    _logger.LogWarning(e, "Error while trying to nofity other instance");
+                }
+
+                _logger.LogDebug("stopping application.");
                 _hostApplicationLifetime.StopApplication();
             }
+            else
+            {
+                _logger.LogDebug("This is the first instance of application {0}, creating named pipe server.", _hostEnvironment.ApplicationName);
 
-            return Task.CompletedTask;
+                _resourceNamedPipeServer = ResourceNamedPipeServer.Create(null, _mutexBuilder.MutexId, _hostEnvironment.ApplicationName, _mutexBuilder.IsGlobal);
+                _resourceNamedPipeServer.Connected += delegate
+                {
+                    _mutexBuilder.WhenOtherInstanceStarts?.Invoke(_hostEnvironment, _logger);
+                };
+            }
         }
 
         private void OnStopping()
         {
-            _logger.LogInformation("OnStopping has been called, closing mutex.");
+            _logger.LogInformation("OnStopping has been called, closing named pipe.");
+            if(_resourceNamedPipeServer != null)
+            {
+                _resourceNamedPipeServer.Dispose();
+            }
+
+            _logger.LogInformation("Also closing mutex.");
             _resourceMutex.Dispose();
         }
 

--- a/src/Dapplo.Microsoft.Extensions.Hosting.AppServices/ResourceNamedPipeClient.cs
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.AppServices/ResourceNamedPipeClient.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Dapplo and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO.Pipes;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+#if NET472
+using System.Security.AccessControl;
+using System.Security.Principal;
+#endif
+
+namespace Dapplo.Microsoft.Extensions.Hosting.AppServices
+{
+    /// <summary>
+    ///    This class is the client resource of a named pipe
+    /// </summary>
+    public sealed class ResourceNamedPipeClient : BaseResourceNamedPipe, IDisposable
+    {
+        private NamedPipeClientStream _applicationNamedPipe;
+
+        private ResourceNamedPipeClient(ILogger logger, string namedPipeId, string resourceName = null) : base(logger, namedPipeId, resourceName)
+        {
+        }
+
+        /// <summary>
+        ///     Create a ResourceNamedPipeServer for the specified named pipe id and resource-name
+        /// </summary>
+        /// <param name="logger">ILogger</param>
+        /// <param name="namedPipeId">ID of the named pipe, preferably a Guid as string</param>
+        /// <param name="resourceName">Name of the resource to lock, e.g your application name, useful for logs</param>
+        /// <param name="global">true to have a global named pipe see: https://msdn.microsoft.com/en-us/library/bwe34f1k.aspx</param>
+        public static async Task<ResourceNamedPipeClient> Create(ILogger logger, string namedPipeId, string resourceName = null, bool global = false)
+        {
+            if (namedPipeId == null)
+            {
+                throw new ArgumentNullException(nameof(namedPipeId));
+            }
+            logger ??= new LoggerFactory().CreateLogger<ResourceNamedPipeServer>();
+            var applicationNamedPipeClient = new ResourceNamedPipeClient(logger, (global ? @"Global\" : @"Local\") + namedPipeId, resourceName);
+            await applicationNamedPipeClient.Connect();
+            return applicationNamedPipeClient;
+        }
+
+        /// <summary>
+        ///     Connects to the server part and sends a signal that we started
+        /// </summary>
+        /// <param name="timeout"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async Task Connect(int timeout = 3000, CancellationToken? cancellationToken = null)
+        {
+            _applicationNamedPipe = new NamedPipeClientStream(".", _namedPipeId, PipeDirection.InOut, PipeOptions.Asynchronous);
+            await  _applicationNamedPipe.ConnectAsync(timeout, cancellationToken ?? CancellationToken.None);
+            await _applicationNamedPipe.WriteAsync(Encoding.ASCII.GetBytes(StartedMagicString), cancellationToken ?? CancellationToken.None);
+        }
+
+        /// <summary>
+        ///     This disposes the named pipe client
+        /// </summary>
+        public void Dispose()
+        {
+            if(_applicationNamedPipe != null)
+            {
+                _applicationNamedPipe.Close();
+                _applicationNamedPipe.Dispose();
+                _applicationNamedPipe = null;
+            }
+        }
+    }
+}

--- a/src/Dapplo.Microsoft.Extensions.Hosting.AppServices/ResourceNamedPipeServer.cs
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.AppServices/ResourceNamedPipeServer.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) Dapplo and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO.Pipes;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+#if NET472
+using System.Security.AccessControl;
+using System.Security.Principal;
+#endif
+
+namespace Dapplo.Microsoft.Extensions.Hosting.AppServices
+{
+    /// <summary>
+    ///     This class is the server resource for a named pipe
+    /// </summary>
+    public sealed class ResourceNamedPipeServer : BaseResourceNamedPipe, IDisposable
+    {
+        private byte[] _buffer = new byte[32];
+        private object _lockingObject = new object();
+        private bool _isStopping = false;
+        private NamedPipeServerStream _applicationNamedPipe;
+
+        private ResourceNamedPipeServer(ILogger logger, string namedPipeId, string resourceName = null) : base(logger, namedPipeId, resourceName)
+        {
+        }
+
+        /// <summary>
+        ///   This event is fired when a named pipe client is connected
+        /// </summary>
+        public event EventHandler Connected;
+
+        /// <summary>
+        ///     Create a ResourceNamedPipeServer for the specified named pipe id and resource-name
+        /// </summary>
+        /// <param name="logger">ILogger</param>
+        /// <param name="namedPipeId">ID of the named pipe, preferably a Guid as string</param>
+        /// <param name="resourceName">Name of the resource to lock, e.g your application name, useful for logs</param>
+        /// <param name="global">true to have a global named pipe see: https://msdn.microsoft.com/en-us/library/bwe34f1k.aspx</param>
+        public static ResourceNamedPipeServer Create(ILogger logger, string namedPipeId, string resourceName = null, bool global = false)
+        {
+            if (namedPipeId == null)
+            {
+                throw new ArgumentNullException(nameof(namedPipeId));
+            }
+            logger ??= new LoggerFactory().CreateLogger<ResourceNamedPipeServer>();
+            var applicationNamedPipeServer = new ResourceNamedPipeServer(logger, (global ? @"Global\" : @"Local\") + namedPipeId, resourceName);
+            applicationNamedPipeServer.Start();
+            return applicationNamedPipeServer;
+        }
+
+        /// <summary>
+        ///     Starts the named pipe server
+        /// </summary>
+        public void Start()
+        {
+            if (_applicationNamedPipe != null)
+                throw new InvalidOperationException("Cannot start a ResourceNamedPipeServer when it is already started");
+
+            if (_isStopping)
+                throw new InvalidOperationException("Cannot start a ResourceNamedPipeServer when it is already stopped");
+
+            _applicationNamedPipe = new NamedPipeServerStream(_namedPipeId, PipeDirection.InOut, 1, PipeTransmissionMode.Message, PipeOptions.Asynchronous);
+
+            try
+            {
+                StartWaitingForConnection();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error while trying to begin listening for a connection on named pipe");
+                throw;
+            }
+        }
+
+        private void StartWaitingForConnection()
+        {
+            _applicationNamedPipe.BeginWaitForConnection(WaitForConnectionCallBack, null);
+        }
+
+        private void WaitForConnectionCallBack(IAsyncResult result)
+        {
+            if (!_isStopping)
+            {
+                lock (_lockingObject)
+                {
+                    if (!_isStopping)
+                    {
+                        // Call EndWaitForConnection to complete the connection operation
+                        _applicationNamedPipe.EndWaitForConnection(result);
+
+                        _applicationNamedPipe.BeginRead(_buffer, 0, 32, BeginReadCallback, null);
+                    }
+                }
+            }
+        }
+
+        private void BeginReadCallback(IAsyncResult result)
+        {
+            var readBytes = _applicationNamedPipe.EndRead(result);
+            if (readBytes > 0)
+            {
+                var message = Encoding.ASCII.GetString(_buffer, 0, readBytes);
+                if(message == StartedMagicString)
+                {
+                    Connected?.Invoke(this, EventArgs.Empty);
+                }
+            }
+
+            if (!_isStopping)
+            {
+                _applicationNamedPipe.Disconnect();
+                StartWaitingForConnection();
+            }
+        }
+
+        /// <summary>
+        ///     Stops the named pipe server
+        /// </summary>
+        public void Stop()
+        {
+            _isStopping = true;
+
+            if(_applicationNamedPipe == null)
+            {
+                _logger.LogWarning("NamedPipeServerResource is already stopped");
+            }
+
+            try
+            {
+                if (_applicationNamedPipe.IsConnected)
+                {
+                    _applicationNamedPipe.Disconnect();
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Exception caught while trying to disconnect named pipe");
+                throw;
+            }
+            finally
+            {
+                _applicationNamedPipe.Close();
+                _applicationNamedPipe.Dispose();
+                _applicationNamedPipe = null;
+            }
+        }
+
+        /// <summary>
+        ///     This disposes the named pipe server
+        /// </summary>
+        public void Dispose()
+        {
+            if (_isStopping)
+                Stop();
+        }
+    }
+}


### PR DESCRIPTION
Hi,

I wonder what you think about this. This patch created a named pipe server with the same name as the mutex when the first instances gets the lock. Any other instances that do not receive the lock connect to the named pipe and send a magic command. The first instance can react to this. 

Handy when you want to let your MainWindow pop to the front for example.