### PR TITLE
Added .NET Framework 4.7.2 support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="!$(MSBuildProjectName.Contains('Sample'))">
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.71">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.74">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Dapplo.Microsoft.Extensions.Hosting.WinForms
 
 [![Nuget](https://img.shields.io/nuget/v/Dapplo.Microsoft.Extensions.Hosting.WinForms.svg)](https://www.nuget.org/packages/Dapplo.Microsoft.Extensions.Hosting.WinForms/)
 
-This extension adds WinForms support to generic host based dotnet core 3.0 applications.
+This extension adds WinForms support to generic host based applications.
 With this you can enhance your application with a UI, and use all the services provided by the generic host like DI, logging etc.
 
 [Here](https://github.com/dapplo/Dapplo.Microsoft.Extensions.Hosting/blob/master/samples/Dapplo.Hosting.Sample.WinFormsDemo/Program.cs#L48) is an example how to start your application with a Form1 and have the application automatically shutdown whenever you exit the Form1. To make this possible Form1 must implement a marker interface, which currently has no methods, called IWinFormsShell. The IWinFormsShell is considered the main entry point of your UI. You only specify the type, the instance will be created at a later time by the generic host and will automatically go through the DI process.
@@ -137,7 +137,7 @@ Dapplo.Microsoft.Extensions.Hosting.CaliburnMicro
 
 [![Nuget](https://img.shields.io/nuget/v/Dapplo.Microsoft.Extensions.Hosting.CaliburnMicro.svg)](https://www.nuget.org/packages/Dapplo.Microsoft.Extensions.Hosting.CaliburnMicro/)
 
-This extension adds [Caliburn.Micro](https://caliburnmicro.com) support to generic host based dotnet core 3.0 applications.
+This extension adds [Caliburn.Micro](https://caliburnmicro.com) support to generic host based applications.
 With this you can enhance your application with a UI, and use all the services provided by the generic host like DI, logging etc, together with this great MVVM framework.
 
 [Here](https://github.com/dapplo/Dapplo.Microsoft.Extensions.Hosting/blob/master/samples/Dapplo.Hosting.Sample.CaliburnMicroDemo/Program.cs#L54) is an example how to start your application with a MainWindowViewModel and have the application automatically shutdown whenever you exit the MainWindowViewModel. To make this possible MainWindowViewModel must implement a marker interface, which currently has no methods, called ICaliburnMicroShell. The ICaliburnMicroShell is considered the main entry point of your UI. You only specify the type, the instance will be created at a later time by the generic host and will automatically go through the DI process.

--- a/samples/Dapplo.Hosting.Sample.CaliburnMicroDemo/Dapplo.Hosting.Sample.CaliburnMicroDemo.csproj
+++ b/samples/Dapplo.Hosting.Sample.CaliburnMicroDemo/Dapplo.Hosting.Sample.CaliburnMicroDemo.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <Platforms>AnyCPU;x64</Platforms>
-	<ApplicationManifest>application.manifest</ApplicationManifest>
+    <ApplicationManifest>application.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Dapplo.Hosting.Sample.CaliburnMicroDemo/Program.cs
+++ b/samples/Dapplo.Hosting.Sample.CaliburnMicroDemo/Program.cs
@@ -41,12 +41,16 @@ namespace Dapplo.Hosting.Sample.CaliburnMicroDemo
                 })
                 .ConfigurePlugins(pluginBuilder =>
                 {
-                    // Specify the location from where the DLL's are "globbed"
-                    pluginBuilder.AddScanDirectories(Path.Combine(executableLocation, @"..\..\..\..\"));
+                    var runtime = Path.GetFileName(executableLocation);
+                    var parentDirectory = Directory.GetParent(executableLocation).FullName;
+                    var configuration = Path.GetFileName(parentDirectory);
+                    var basePath = Path.Combine(executableLocation, @"..\..\..\..\");
+                    // Specify the location from where the Dll's are "globbed"
+                    pluginBuilder.AddScanDirectories(basePath);
                     // Add the framework libraries which can be found with the specified globs
-                    pluginBuilder.IncludeFrameworks(@"**\bin\**\*.FrameworkLib.dll");
+                    pluginBuilder.IncludeFrameworks(@$"**\bin\{configuration}\netstandard2.0\*.FrameworkLib.dll");
                     // Add the plugins which can be found with the specified globs
-                    pluginBuilder.IncludePlugins(@"**\bin\**\*.Plugin*.dll");
+                    pluginBuilder.IncludePlugins(@$"**\bin\{configuration}\{runtime}\*.Sample.Plugin*.dll");
                 })
                 .ConfigureCaliburnMicro<MainViewModel>()
                 .ConfigureServices(serviceCollection =>

--- a/samples/Dapplo.Hosting.Sample.ConsoleDemo/Dapplo.Hosting.Sample.ConsoleDemo.csproj
+++ b/samples/Dapplo.Hosting.Sample.ConsoleDemo/Dapplo.Hosting.Sample.ConsoleDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 

--- a/samples/Dapplo.Hosting.Sample.ConsoleDemo/Program.cs
+++ b/samples/Dapplo.Hosting.Sample.ConsoleDemo/Program.cs
@@ -27,12 +27,16 @@ namespace Dapplo.Hosting.Sample.ConsoleDemo
                 .ConfigureConfiguration(args)
                 .ConfigurePlugins(pluginBuilder =>
                 {
-                    // Specify the location from where the dll's are "globbed"
-                    pluginBuilder.AddScanDirectories(Path.Combine(executableLocation, @"..\..\..\..\"));
+                    var runtime = Path.GetFileName(executableLocation);
+                    var parentDirectory = Directory.GetParent(executableLocation).FullName;
+                    var configuration = Path.GetFileName(parentDirectory);
+                    var basePath = Path.Combine(executableLocation, @"..\..\..\..\");
+                    // Specify the location from where the Dll's are "globbed"
+                    pluginBuilder.AddScanDirectories(basePath);
                     // Add the framework libraries which can be found with the specified globs
-                    pluginBuilder.IncludeFrameworks(@"**\bin\**\*.FrameworkLib.dll");
+                    pluginBuilder.IncludeFrameworks(@$"**\bin\{configuration}\netstandard2.0\*.FrameworkLib.dll");
                     // Add the plugins which can be found with the specified globs
-                    pluginBuilder.IncludePlugins(@"**\bin\**\*.Plugin*.dll");
+                    pluginBuilder.IncludePlugins(@$"**\bin\{configuration}\{runtime}\*.Sample.Plugin*.dll");
                 })
                 .UseConsoleLifetime()
                 .Build();

--- a/samples/Dapplo.Hosting.Sample.MetroDemo/Dapplo.Hosting.Sample.MetroDemo.csproj
+++ b/samples/Dapplo.Hosting.Sample.MetroDemo/Dapplo.Hosting.Sample.MetroDemo.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <Platforms>AnyCPU;x64</Platforms>
-	<ApplicationManifest>application.manifest</ApplicationManifest>
+    <ApplicationManifest>application.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Dapplo.Hosting.Sample.MetroDemo/Program.cs
+++ b/samples/Dapplo.Hosting.Sample.MetroDemo/Program.cs
@@ -39,12 +39,16 @@ namespace Dapplo.Hosting.Sample.MetroDemo
                 })
                 .ConfigurePlugins(pluginBuilder =>
                 {
+                    var runtime = Path.GetFileName(executableLocation);
+                    var parentDirectory = Directory.GetParent(executableLocation).FullName;
+                    var configuration = Path.GetFileName(parentDirectory);
+                    var basePath = Path.Combine(executableLocation, @"..\..\..\..\");
                     // Specify the location from where the Dll's are "globbed"
-                    pluginBuilder.AddScanDirectories(Path.Combine(executableLocation, @"..\..\..\..\"));
+                    pluginBuilder.AddScanDirectories(basePath);
                     // Add the framework libraries which can be found with the specified globs
-                    pluginBuilder.IncludeFrameworks(@"**\bin\**\*.FrameworkLib.dll");
+                    pluginBuilder.IncludeFrameworks(@$"**\bin\{configuration}\netstandard2.0\*.FrameworkLib.dll");
                     // Add the plugins which can be found with the specified globs
-                    pluginBuilder.IncludePlugins(@"**\bin\**\*.Plugin*.dll");
+                    pluginBuilder.IncludePlugins(@$"**\bin\{configuration}\{runtime}\*.Sample.Plugin*.dll");
                 })
                 .ConfigureServices(serviceCollection =>
                 {

--- a/samples/Dapplo.Hosting.Sample.PluginOriginalSample/Dapplo.Hosting.Sample.PluginOriginalSample.csproj
+++ b/samples/Dapplo.Hosting.Sample.PluginOriginalSample/Dapplo.Hosting.Sample.PluginOriginalSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 

--- a/samples/Dapplo.Hosting.Sample.PluginOriginalSample/Dapplo.Hosting.Sample.PluginOriginalSample.csproj
+++ b/samples/Dapplo.Hosting.Sample.PluginOriginalSample/Dapplo.Hosting.Sample.PluginOriginalSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 

--- a/samples/Dapplo.Hosting.Sample.PluginWithDependency/Dapplo.Hosting.Sample.PluginWithDependency.csproj
+++ b/samples/Dapplo.Hosting.Sample.PluginWithDependency/Dapplo.Hosting.Sample.PluginWithDependency.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 

--- a/samples/Dapplo.Hosting.Sample.ReactiveDemo/Dapplo.Hosting.Sample.ReactiveDemo.csproj
+++ b/samples/Dapplo.Hosting.Sample.ReactiveDemo/Dapplo.Hosting.Sample.ReactiveDemo.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <Platforms>AnyCPU;x64</Platforms>
-	<ApplicationManifest>application.manifest</ApplicationManifest>
+	  <ApplicationManifest>application.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Dapplo.Hosting.Sample.ReactiveDemo/Dapplo.Hosting.Sample.ReactiveDemo.csproj
+++ b/samples/Dapplo.Hosting.Sample.ReactiveDemo/Dapplo.Hosting.Sample.ReactiveDemo.csproj
@@ -16,11 +16,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
-    <PackageReference Include="ReactiveUI.WPF" Version="11.2.3" />
-    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="9.3.11" />
+    <PackageReference Include="NuGet.Protocol" Version="5.5.0" />
+    <PackageReference Include="ReactiveUI.WPF" Version="11.3.1" />
+    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="9.4.1" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
-    <PackageReference Include="NuGet.Client" Version="4.2.0" />
-    <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Dapplo.Hosting.Sample.ReactiveDemo/Program.cs
+++ b/samples/Dapplo.Hosting.Sample.ReactiveDemo/Program.cs
@@ -42,12 +42,16 @@ namespace Dapplo.Hosting.Sample.ReactiveDemo
                 })
                 .ConfigurePlugins(pluginBuilder =>
                 {
-                    // Specify the location from where the DLL's are "globbed"
-                    pluginBuilder.AddScanDirectories(Path.Combine(executableLocation, @"..\..\..\..\"));
+                    var runtime = Path.GetFileName(executableLocation);
+                    var parentDirectory = Directory.GetParent(executableLocation).FullName;
+                    var configuration = Path.GetFileName(parentDirectory);
+                    var basePath = Path.Combine(executableLocation, @"..\..\..\..\");
+                    // Specify the location from where the Dll's are "globbed"
+                    pluginBuilder.AddScanDirectories(basePath);
                     // Add the framework libraries which can be found with the specified globs
-                    pluginBuilder.IncludeFrameworks(@"**\bin\**\*.FrameworkLib.dll");
+                    pluginBuilder.IncludeFrameworks(@$"**\bin\{configuration}\netstandard2.0\*.FrameworkLib.dll");
                     // Add the plugins which can be found with the specified globs
-                    pluginBuilder.IncludePlugins(@"**\bin\**\*.Plugin*.dll");
+                    pluginBuilder.IncludePlugins(@$"**\bin\{configuration}\{runtime}\*.Sample.Plugin*.dll");
                 })
                 .ConfigureServices(serviceCollection =>
                 {

--- a/samples/Dapplo.Hosting.Sample.WinFormsDemo/Dapplo.Hosting.Sample.WinFormsDemo.csproj
+++ b/samples/Dapplo.Hosting.Sample.WinFormsDemo/Dapplo.Hosting.Sample.WinFormsDemo.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <Platforms>AnyCPU;x64</Platforms>
-	<ApplicationManifest>application.manifest</ApplicationManifest>
+    <ApplicationManifest>application.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Dapplo.Hosting.Sample.WinFormsDemo/Dapplo.Hosting.Sample.WinFormsDemo.csproj
+++ b/samples/Dapplo.Hosting.Sample.WinFormsDemo/Dapplo.Hosting.Sample.WinFormsDemo.csproj
@@ -15,8 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dapplo.Microsoft.Extensions.Hosting.AppServices\Dapplo.Microsoft.Extensions.Hosting.AppServices.csproj" />
-    <ProjectReference Include="..\..\src\Dapplo.Microsoft.Extensions.Hosting.Plugins\Dapplo.Microsoft.Extensions.Hosting.Plugins.csproj" />
     <ProjectReference Include="..\..\src\Dapplo.Microsoft.Extensions.Hosting.WinForms\Dapplo.Microsoft.Extensions.Hosting.WinForms.csproj" />
+    <ProjectReference Include="..\..\src\Dapplo.Microsoft.Extensions.Hosting.Plugins\Dapplo.Microsoft.Extensions.Hosting.Plugins.csproj" />
   </ItemGroup>
-
 </Project>

--- a/samples/Dapplo.Hosting.Sample.WinFormsDemo/Program.cs
+++ b/samples/Dapplo.Hosting.Sample.WinFormsDemo/Program.cs
@@ -38,12 +38,16 @@ namespace Dapplo.Hosting.Sample.WinFormsDemo
                 })
                 .ConfigurePlugins(pluginBuilder =>
                 {
+                    var runtime = Path.GetFileName(executableLocation);
+                    var parentDirectory = Directory.GetParent(executableLocation).FullName;
+                    var configuration = Path.GetFileName(parentDirectory);
+                    var basePath = Path.Combine(executableLocation, @"..\..\..\..\");
                     // Specify the location from where the Dll's are "globbed"
-                    pluginBuilder.AddScanDirectories(Path.Combine(executableLocation, @"..\..\..\..\"));
+                    pluginBuilder.AddScanDirectories(basePath);
                     // Add the framework libraries which can be found with the specified globs
-                    pluginBuilder.IncludeFrameworks(@"**\bin\**\*.FrameworkLib.dll");
+                    pluginBuilder.IncludeFrameworks(@$"**\bin\{configuration}\netstandard2.0\*.FrameworkLib.dll");
                     // Add the plugins which can be found with the specified globs
-                    pluginBuilder.IncludePlugins(@"**\bin\**\*.Plugin*.dll");
+                    pluginBuilder.IncludePlugins(@$"**\bin\{configuration}\{runtime}\*.Sample.Plugin*.dll");
                 })
                 .ConfigureServices(serviceCollection =>
                 {

--- a/samples/Dapplo.Hosting.Sample.WpfDemo/Dapplo.Hosting.Sample.WpfDemo.csproj
+++ b/samples/Dapplo.Hosting.Sample.WpfDemo/Dapplo.Hosting.Sample.WpfDemo.csproj
@@ -14,8 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dapplo.Microsoft.Extensions.Hosting.AppServices\Dapplo.Microsoft.Extensions.Hosting.AppServices.csproj" />
-    <ProjectReference Include="..\..\src\Dapplo.Microsoft.Extensions.Hosting.Plugins\Dapplo.Microsoft.Extensions.Hosting.Plugins.csproj" />
     <ProjectReference Include="..\..\src\Dapplo.Microsoft.Extensions.Hosting.Wpf\Dapplo.Microsoft.Extensions.Hosting.Wpf.csproj" />
+    <ProjectReference Include="..\..\src\Dapplo.Microsoft.Extensions.Hosting.Plugins\Dapplo.Microsoft.Extensions.Hosting.Plugins.csproj" />
   </ItemGroup>
-
 </Project>

--- a/samples/Dapplo.Hosting.Sample.WpfDemo/Dapplo.Hosting.Sample.WpfDemo.csproj
+++ b/samples/Dapplo.Hosting.Sample.WpfDemo/Dapplo.Hosting.Sample.WpfDemo.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <Platforms>AnyCPU;x64</Platforms>
-	<ApplicationManifest>application.manifest</ApplicationManifest>
+    <ApplicationManifest>application.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Dapplo.Hosting.Sample.WpfDemo/Program.cs
+++ b/samples/Dapplo.Hosting.Sample.WpfDemo/Program.cs
@@ -37,12 +37,16 @@ namespace Dapplo.Hosting.Sample.WpfDemo
                 })
                 .ConfigurePlugins(pluginBuilder =>
                 {
+                    var runtime = Path.GetFileName(executableLocation);
+                    var parentDirectory = Directory.GetParent(executableLocation).FullName;
+                    var configuration = Path.GetFileName(parentDirectory);
+                    var basePath = Path.Combine(executableLocation, @"..\..\..\..\");
                     // Specify the location from where the Dll's are "globbed"
-                    pluginBuilder.AddScanDirectories(Path.Combine(executableLocation, @"..\..\..\..\"));
+                    pluginBuilder.AddScanDirectories(basePath);
                     // Add the framework libraries which can be found with the specified globs
-                    pluginBuilder.IncludeFrameworks(@"**\bin\**\*.FrameworkLib.dll");
+                    pluginBuilder.IncludeFrameworks(@$"**\bin\{configuration}\netstandard2.0\*.FrameworkLib.dll");
                     // Add the plugins which can be found with the specified globs
-                    pluginBuilder.IncludePlugins(@"**\bin\**\*.Plugin*.dll");
+                    pluginBuilder.IncludePlugins(@$"**\bin\{configuration}\{runtime}\*.Sample.Plugin*.dll");
                 })
                 .ConfigureServices(serviceCollection =>
                 {

--- a/src/Dapplo.Microsoft.Extensions.Hosting.AppServices/Dapplo.Microsoft.Extensions.Hosting.AppServices.csproj
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.AppServices/Dapplo.Microsoft.Extensions.Hosting.AppServices.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     <PackageDescription>This extension adds some generic application services for desktop applications.</PackageDescription>
   </PropertyGroup>

--- a/src/Dapplo.Microsoft.Extensions.Hosting.CaliburnMicro/CaliburnMicroBootstrapper.cs
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.CaliburnMicro/CaliburnMicroBootstrapper.cs
@@ -8,7 +8,9 @@ using Caliburn.Micro;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
+#if NETCOREAPP
 using System.Runtime.Loader;
+#endif
 using Microsoft.Extensions.DependencyInjection;
 using Dapplo.Microsoft.Extensions.Hosting.Wpf;
 
@@ -64,7 +66,7 @@ namespace Dapplo.Microsoft.Extensions.Hosting.CaliburnMicro
         }
 
         /// <summary>
-        ///     Configure the Dapplo.Addon.Bootstrapper with the AssemblySource.Instance values
+        ///     Configure Caliburn.Micro
         /// </summary>
         [SuppressMessage("Sonar Code Smell", "S2696:Instance members should not write to static fields", Justification = "This is the only location where it makes sense.")]
         protected override void Configure()
@@ -141,7 +143,11 @@ namespace Dapplo.Microsoft.Extensions.Hosting.CaliburnMicro
         /// <inheritdoc />
         protected override IEnumerable<Assembly> SelectAssemblies()
         {
+#if NETCOREAPP
             return AssemblyLoadContext.Default.Assemblies;
+#else
+            return AppDomain.CurrentDomain.GetAssemblies();
+#endif
         }
 
         /// <inheritdoc />

--- a/src/Dapplo.Microsoft.Extensions.Hosting.CaliburnMicro/Dapplo.Microsoft.Extensions.Hosting.CaliburnMicro.csproj
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.CaliburnMicro/Dapplo.Microsoft.Extensions.Hosting.CaliburnMicro.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <Platforms>AnyCPU;x64</Platforms>
-    <PackageDescription>This extension adds Caliburn.Micro support to generic host based dotnet core 3.0 WPF applications. With this you can enhance your application with a UI, and use all the services provided by the generic host like DI, logging etc, together with this great MVVM framework.</PackageDescription>
+    <PackageDescription>This extension adds Caliburn.Micro support to generic host based WPF applications. With this you can enhance your application with a UI, and use all the services provided by the generic host like DI, logging etc, together with this great MVVM framework.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Dapplo.Microsoft.Extensions.Hosting.Metro/Dapplo.Microsoft.Extensions.Hosting.Metro.csproj
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.Metro/Dapplo.Microsoft.Extensions.Hosting.Metro.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MahApps.Metro" Version="2.0.0-alpha0660" />
+    <PackageReference Include="MahApps.Metro" Version="2.0.0-alpha0748" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dapplo.Microsoft.Extensions.Hosting.Metro/Dapplo.Microsoft.Extensions.Hosting.Metro.csproj
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.Metro/Dapplo.Microsoft.Extensions.Hosting.Metro.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-	  <UseWPF>true</UseWPF>
-	  <Platforms>AnyCPU;x64</Platforms>
-    <PackageDescription>This extension adds MahApps.Metro support to generic host based dotnet core 3.0 WPF applications. With this you can enhance your application with a UI, and use all the services provided by the generic host like DI, logging etc, together with this UI framework for WPF.</PackageDescription>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <UseWPF>true</UseWPF>
+    <Platforms>AnyCPU;x64</Platforms>
+    <PackageDescription>This extension adds MahApps.Metro support to generic host based WPF applications. With this you can enhance your application with a UI, and use all the services provided by the generic host like DI, logging etc, together with this UI framework for WPF.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Dapplo.Microsoft.Extensions.Hosting.Plugins/Dapplo.Microsoft.Extensions.Hosting.Plugins.csproj
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.Plugins/Dapplo.Microsoft.Extensions.Hosting.Plugins.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
-    <PackageDescription>This extension adds plug-in support to generic host based dotnet core 3.0 applications.</PackageDescription>
+    <PackageDescription>This extension adds plug-in support to generic host based dapplications.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Dapplo.Microsoft.Extensions.Hosting.Plugins/Dapplo.Microsoft.Extensions.Hosting.Plugins.csproj
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.Plugins/Dapplo.Microsoft.Extensions.Hosting.Plugins.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
-    <PackageDescription>This extension adds plug-in support to generic host based dapplications.</PackageDescription>
+    <PackageDescription>This extension adds plug-in support to generic host based applications.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Dapplo.Microsoft.Extensions.Hosting.Plugins/HostBuilderPluginExtensions.cs
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.Plugins/HostBuilderPluginExtensions.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+#if NETCOREAPP
 using System.Runtime.Loader;
+#endif
 using Dapplo.Microsoft.Extensions.Hosting.Plugins.Internals;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Hosting;

--- a/src/Dapplo.Microsoft.Extensions.Hosting.Plugins/Internals/AssemblyDependencyResolver.cs
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.Plugins/Internals/AssemblyDependencyResolver.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Dapplo and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection;
+
+namespace Dapplo.Microsoft.Extensions.Hosting.Plugins.Internals
+{
+#if !NETCOREAPP
+    /// <summary>
+    /// This is a wrapper class to simulate the behavior of the AssemblyDependencyResolver under the .NET Framework
+    /// </summary>
+    public class AssemblyDependencyResolver
+    {
+        private readonly string _pluginPath;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="pluginPath">string with the path for the plugin and where his dependencies are loaded from</param>
+        public AssemblyDependencyResolver(string pluginPath)
+        {
+            _pluginPath = pluginPath;
+        }
+
+        /// <summary>
+        /// Find the assembly in the directory of the plugin
+        /// </summary>
+        /// <param name="assemblyName">AssemblyName</param>
+        /// <returns>string path for the assembly</returns>
+        /// <exception cref="NotImplementedException"></exception>
+        public string ResolveAssemblyToPath(AssemblyName assemblyName)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Find the location of an unmanaged DLL
+        /// </summary>
+        /// <param name="unmanagedDllName">string</param>
+        /// <returns>string with the path</returns>
+        /// <exception cref="NotImplementedException"></exception>
+        public string ResolveUnmanagedDllToPath(string unmanagedDllName)
+        {
+            throw new NotImplementedException();
+        }
+    }
+#endif
+}

--- a/src/Dapplo.Microsoft.Extensions.Hosting.Plugins/Internals/AssemblyDependencyResolver.cs
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.Plugins/Internals/AssemblyDependencyResolver.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) Dapplo and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !NETCOREAPP
 using System;
+using System.IO;
 using System.Reflection;
 
 namespace Dapplo.Microsoft.Extensions.Hosting.Plugins.Internals
 {
-#if !NETCOREAPP
     /// <summary>
     /// This is a wrapper class to simulate the behavior of the AssemblyDependencyResolver under the .NET Framework
     /// </summary>
@@ -20,7 +21,7 @@ namespace Dapplo.Microsoft.Extensions.Hosting.Plugins.Internals
         /// <param name="pluginPath">string with the path for the plugin and where his dependencies are loaded from</param>
         public AssemblyDependencyResolver(string pluginPath)
         {
-            _pluginPath = pluginPath;
+            _pluginPath = System.IO.Path.GetDirectoryName(pluginPath);
         }
 
         /// <summary>
@@ -31,7 +32,13 @@ namespace Dapplo.Microsoft.Extensions.Hosting.Plugins.Internals
         /// <exception cref="NotImplementedException"></exception>
         public string ResolveAssemblyToPath(AssemblyName assemblyName)
         {
-            throw new NotImplementedException();
+            var assemblyPath = Path.Combine(_pluginPath, $"{assemblyName.Name}.dll");
+            if (File.Exists(assemblyPath))
+            {
+                return assemblyPath;
+            }
+
+            return null;
         }
 
         /// <summary>
@@ -45,5 +52,5 @@ namespace Dapplo.Microsoft.Extensions.Hosting.Plugins.Internals
             throw new NotImplementedException();
         }
     }
-#endif
 }
+#endif

--- a/src/Dapplo.Microsoft.Extensions.Hosting.Plugins/Internals/AssemblyLoadContext.cs
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.Plugins/Internals/AssemblyLoadContext.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Dapplo and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Dapplo.Microsoft.Extensions.Hosting.Plugins.Internals
+{
+#if !NETCOREAPP
+    /// <summary>
+    /// This is a wrapper class to simulate the behavior of the AssemblyLoadContext under the .NET Framework
+    /// </summary>
+    public class AssemblyLoadContext
+    {
+        /// <summary>
+        /// Default AssemblyLoadContext
+        /// </summary>
+        public static AssemblyLoadContext Default { get; } = new AssemblyLoadContext("default");
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        /// <param name="name"></param>
+        public AssemblyLoadContext(string name)
+        {
+            Name = name;
+        }
+
+        /// <summary>
+        /// The name of the AssemblyLoadContext
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Returns all the available assemblies
+        /// </summary>
+        public IEnumerable<Assembly> Assemblies => AppDomain.CurrentDomain.GetAssemblies();
+
+        /// <summary>
+        /// Implement the loading of the assembly
+        /// </summary>
+        /// <param name="assemblyName">AssemblyName</param>
+        /// <returns>Assembly</returns>
+        protected virtual Assembly Load(AssemblyName assemblyName)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Load the assembly by name
+        /// </summary>
+        /// <param name="assemblyName">AssemblyName</param>
+        /// <returns>Assembly</returns>
+        public Assembly LoadFromAssemblyName(AssemblyName assemblyName)
+        {
+            if (assemblyName == null)
+                throw new ArgumentNullException(nameof(assemblyName));
+
+            // Attempt to load the assembly, using the same ordering as static load, in the current load context.
+            return Assembly.Load(assemblyName);
+        }
+
+        /// <summary>
+        /// Load an assembly from the path
+        /// </summary>
+        /// <param name="assemblyPath">string with the path to the assembly file</param>
+        /// <returns>Assembly</returns>
+        public Assembly LoadFromAssemblyPath(string assemblyPath)
+        {
+            return Assembly.LoadFrom(assemblyPath);
+        }
+
+        /// <summary>
+        /// Load the DLL from the specified path
+        /// </summary>
+        /// <param name="dllPath">string</param>
+        /// <returns>IntPtr</returns>
+        protected IntPtr LoadUnmanagedDllFromPath(string dllPath)
+        {
+            return IntPtr.Zero;
+        }
+
+        /// <summary>
+        /// Loads the specified DLL from the plugin path
+        /// </summary>
+        /// <param name="unmanagedDllName">string</param>
+        /// <returns>IntPtr</returns>
+        protected virtual IntPtr LoadUnmanagedDll(string unmanagedDllName)
+        {
+            return IntPtr.Zero;
+        }
+    }
+#endif
+}

--- a/src/Dapplo.Microsoft.Extensions.Hosting.Plugins/Internals/AssemblyLoadContext.cs
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.Plugins/Internals/AssemblyLoadContext.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Dapplo and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#if !NETCOREAPP
 
 using System;
 using System.Collections.Generic;
@@ -7,7 +8,6 @@ using System.Reflection;
 
 namespace Dapplo.Microsoft.Extensions.Hosting.Plugins.Internals
 {
-#if !NETCOREAPP
     /// <summary>
     /// This is a wrapper class to simulate the behavior of the AssemblyLoadContext under the .NET Framework
     /// </summary>
@@ -55,10 +55,12 @@ namespace Dapplo.Microsoft.Extensions.Hosting.Plugins.Internals
         public Assembly LoadFromAssemblyName(AssemblyName assemblyName)
         {
             if (assemblyName == null)
+            {
                 throw new ArgumentNullException(nameof(assemblyName));
+            }
 
             // Attempt to load the assembly, using the same ordering as static load, in the current load context.
-            return Assembly.Load(assemblyName);
+            return Load(assemblyName);
         }
 
         /// <summary>
@@ -91,5 +93,5 @@ namespace Dapplo.Microsoft.Extensions.Hosting.Plugins.Internals
             return IntPtr.Zero;
         }
     }
-#endif
 }
+#endif

--- a/src/Dapplo.Microsoft.Extensions.Hosting.Plugins/Internals/AssemblyLoadContextExtensions.cs
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.Plugins/Internals/AssemblyLoadContextExtensions.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+#if NETCOREAPP
 using System.Runtime.Loader;
+#endif
 
 namespace Dapplo.Microsoft.Extensions.Hosting.Plugins.Internals
 {

--- a/src/Dapplo.Microsoft.Extensions.Hosting.Plugins/Internals/PluginLoadContext.cs
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.Plugins/Internals/PluginLoadContext.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Reflection;
+#if NETCOREAPP
 using System.Runtime.Loader;
+#endif
 
 namespace Dapplo.Microsoft.Extensions.Hosting.Plugins.Internals
 {

--- a/src/Dapplo.Microsoft.Extensions.Hosting.WinForms/Dapplo.Microsoft.Extensions.Hosting.WinForms.csproj
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.WinForms/Dapplo.Microsoft.Extensions.Hosting.WinForms.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <Platforms>AnyCPU;x64</Platforms>
-    <PackageDescription>This extension adds WinForms support to generic host based dotnet core 3.0 applications. With this you can enhance your application with a UI, and use all the services provided by the generic host like DI, logging etc.</PackageDescription>
+    <PackageDescription>This extension adds WinForms support to generic host based applications. With this you can enhance your application with a UI, and use all the services provided by the generic host like DI, logging etc.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Dapplo.Microsoft.Extensions.Hosting.Wpf/Dapplo.Microsoft.Extensions.Hosting.Wpf.csproj
+++ b/src/Dapplo.Microsoft.Extensions.Hosting.Wpf/Dapplo.Microsoft.Extensions.Hosting.Wpf.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <Platforms>AnyCPU;x64</Platforms>
-    <PackageDescription>This extension adds WPF support to generic host based dotnet core 3.0 applications. With this you can enhance your application with a UI, and use all the services provided by the generic host like DI, logging etc.</PackageDescription>
+    <PackageDescription>This extension adds WPF support to generic host applications. With this you can enhance your application with a UI, and use all the services provided by the generic host like DI, logging etc.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>

--- a/templates/Dapplo.Microsoft.Extensions.Hosting.CaliburnMicro.Template/content/Dapplo.Microsoft.Extensions.Hosting.CaliburnMicro.Template.csproj
+++ b/templates/Dapplo.Microsoft.Extensions.Hosting.CaliburnMicro.Template/content/Dapplo.Microsoft.Extensions.Hosting.CaliburnMicro.Template.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <UseWPF>true</UseWPF>
-	<ApplicationManifest>application.manifest</ApplicationManifest>
+    <ApplicationManifest>application.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This was discussed in #22, and actually not that much work.
I've included shims for the AssemblyLoadContext & AssemblyDependencyResolver which are not available in the Framework. These are not complete, but can be enhanced later.

In the current state, the demo works. I expect some issues with more complex projects.